### PR TITLE
[FOUNDATION-005] Finalize issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,43 +1,55 @@
----
-name: Feature
-about: Product feature or user-facing workflow.
-title: "[FEATURE] "
-labels: feature, needs-human-review
-assignees: ""
----
-
 # Feature
 
-## User Story
+**Issue Type:** Feature  
+**Priority:** (High / Medium / Low)  
+**Mode:** Structured Mode / Creative Mode
 
-As a TODO, I want TODO, so that TODO.
+---
 
-## Product Context
+### Context
 
-Describe the product area and why the feature matters.
+### User Story
 
-## Scope
+As a [тип пользователя], I want to [действие], so that [польза].
 
-Included:
+### Operating Mode
 
-- TODO
+- **Structured Mode** — строгий режим
+- **Creative Mode** — разрешено улучшения в рамках ограничений
 
-Excluded:
+### Functional Requirements
 
-- TODO
+- FR-1: ...
+- FR-2: ...
 
-## Contracts
+### Non-Functional Requirements
 
-List API, event, or AI-agent contracts that must be created or changed.
+### Constraints
 
-- TODO
+### Allowed / Forbidden Changes
 
-## Acceptance Criteria
+**Allowed:**
+- ...
 
-- [ ] TODO
+**Forbidden:**
+- ...
 
-## Validation
+### Architecture Impact
 
-Describe required tests, screenshots, or manual checks.
+### AI Guidance & Constraints
 
-- TODO
+Правила для AI-агентов (Codex / Cursor / Claude / Qwen):
+
+### AI Self-Review Checklist
+
+Перед отправкой PR выполнить самопроверку по `prompts/reviews/ai-self-review.md` (если файл существует).
+
+### Acceptance Criteria
+
+- [ ] ...
+- [ ] Соответствует Design System
+- [ ] ...
+
+### Human Review Required
+
+**Да**

--- a/.github/ISSUE_TEMPLATE/foundation.md
+++ b/.github/ISSUE_TEMPLATE/foundation.md
@@ -1,45 +1,48 @@
----
-name: Foundation / Governance
-about: Repository structure, governance, architecture, contracts, or AI-native SDLC work.
-title: "[FOUNDATION] "
-labels: foundation, governance, needs-human-review
-assignees: ""
----
-
 # Foundation / Governance
 
-## Context
+**Issue Type:** Foundation  
+**Priority:** (High / Medium / Low)  
+**Mode:** Structured Mode / Creative Mode
 
-Describe the foundation or governance problem this issue addresses.
+---
 
-## Objective
+### Context
 
-What should be true after this issue is completed?
+### User Story
 
-## Scope
+As a [роль], I want to [действие], so that [цель].
 
-Included:
+### Operating Mode
 
-- TODO
+- **Structured Mode** — строгий режим (по умолчанию)
+- **Creative Mode** — разрешено предлагать улучшения
 
-Excluded:
+### Functional Requirements
 
-- TODO
+- FR-1: ...
+- FR-2: ...
 
-## Acceptance Criteria
+### Constraints
 
-- [ ] TODO
+### Allowed / Forbidden Changes
 
-## Operating Mode
+**Allowed:**
+- ...
 
-- [ ] Structured Mode
-- [ ] Creative Mode with explicit assumptions
+**Forbidden:**
+- ...
 
-## Human Review
+### Architecture Impact
 
-Review focus:
+### AI Guidance & Constraints
 
-- [ ] Architecture
-- [ ] Governance
-- [ ] Security
-- [ ] Product ownership
+Правила для AI-агентов (Codex / Cursor / Claude / Qwen):
+
+### Acceptance Criteria
+
+- [ ] ...
+- [ ] ...
+
+### Human Review Required
+
+**Да**

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-23T19:50:23.627Z for PR creation at branch issue-28-08e0a8a4f584 for issue https://github.com/G-Ivan-A/open-ai.ru/issues/28

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-23T19:50:23.627Z for PR creation at branch issue-28-08e0a8a4f584 for issue https://github.com/G-Ivan-A/open-ai.ru/issues/28

--- a/tests/validate-issue-templates.sh
+++ b/tests/validate-issue-templates.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+foundation_expected="$(mktemp)"
+feature_expected="$(mktemp)"
+trap 'rm -f "$foundation_expected" "$feature_expected"' EXIT
+
+cat > "$foundation_expected" <<'EOF'
+# Foundation / Governance
+
+**Issue Type:** Foundation  
+**Priority:** (High / Medium / Low)  
+**Mode:** Structured Mode / Creative Mode
+
+---
+
+### Context
+
+### User Story
+
+As a [роль], I want to [действие], so that [цель].
+
+### Operating Mode
+
+- **Structured Mode** — строгий режим (по умолчанию)
+- **Creative Mode** — разрешено предлагать улучшения
+
+### Functional Requirements
+
+- FR-1: ...
+- FR-2: ...
+
+### Constraints
+
+### Allowed / Forbidden Changes
+
+**Allowed:**
+- ...
+
+**Forbidden:**
+- ...
+
+### Architecture Impact
+
+### AI Guidance & Constraints
+
+Правила для AI-агентов (Codex / Cursor / Claude / Qwen):
+
+### Acceptance Criteria
+
+- [ ] ...
+- [ ] ...
+
+### Human Review Required
+
+**Да**
+EOF
+
+cat > "$feature_expected" <<'EOF'
+# Feature
+
+**Issue Type:** Feature  
+**Priority:** (High / Medium / Low)  
+**Mode:** Structured Mode / Creative Mode
+
+---
+
+### Context
+
+### User Story
+
+As a [тип пользователя], I want to [действие], so that [польза].
+
+### Operating Mode
+
+- **Structured Mode** — строгий режим
+- **Creative Mode** — разрешено улучшения в рамках ограничений
+
+### Functional Requirements
+
+- FR-1: ...
+- FR-2: ...
+
+### Non-Functional Requirements
+
+### Constraints
+
+### Allowed / Forbidden Changes
+
+**Allowed:**
+- ...
+
+**Forbidden:**
+- ...
+
+### Architecture Impact
+
+### AI Guidance & Constraints
+
+Правила для AI-агентов (Codex / Cursor / Claude / Qwen):
+
+### AI Self-Review Checklist
+
+Перед отправкой PR выполнить самопроверку по `prompts/reviews/ai-self-review.md` (если файл существует).
+
+### Acceptance Criteria
+
+- [ ] ...
+- [ ] Соответствует Design System
+- [ ] ...
+
+### Human Review Required
+
+**Да**
+EOF
+
+diff -u "$foundation_expected" .github/ISSUE_TEMPLATE/foundation.md
+diff -u "$feature_expected" .github/ISSUE_TEMPLATE/feature.md
+
+if [[ -e .github/ISSUE_TEMPLATE/research.md ]]; then
+  printf 'FAIL: .github/ISSUE_TEMPLATE/research.md should not exist\n' >&2
+  exit 1
+fi
+
+printf 'Issue template validation passed.\n'

--- a/tests/validate-repository-structure.sh
+++ b/tests/validate-repository-structure.sh
@@ -31,6 +31,7 @@ required_root_entries=(
   ".env.example"
   ".gitattributes"
   ".github"
+  ".gitkeep"
   ".gitignore"
   "AI_GOVERNANCE.md"
   "CHANGELOG.md"
@@ -107,6 +108,7 @@ required_files=(
   "CHANGELOG.md"
   "LICENSE"
   "docs/governance/repository-labels.md"
+  "tests/validate-issue-templates.sh"
   "tests/validate-repository-structure.sh"
 )
 
@@ -146,6 +148,8 @@ done
 for path in "${legacy_paths[@]}"; do
   reject_path "$path"
 done
+
+"$ROOT_DIR/tests/validate-issue-templates.sh"
 
 if [[ "$failures" -gt 0 ]]; then
   printf '\nRepository structure validation failed with %d issue(s).\n' "$failures" >&2


### PR DESCRIPTION
## Summary
- Replaced `.github/ISSUE_TEMPLATE/foundation.md` with the approved Foundation / Governance template structure.
- Replaced `.github/ISSUE_TEMPLATE/feature.md` with the approved Feature template structure.
- Added exact issue-template validation and wired it into repository structure validation.
- Confirmed `.github/ISSUE_TEMPLATE/research.md` is absent.

Fixes G-Ivan-A/open-ai.ru#28

## Validation
- `./tests/validate-issue-templates.sh`
- `./tests/validate-repository-structure.sh`

## Notes
- The template text intentionally keeps Markdown two-space line breaks where required by the approved issue specification.