### PR TITLE
[FOUNDATION-004] Link portal methodology in CONTRIBUTING.md

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-05-24T11:12:35.088Z for PR creation at branch issue-34-d8afe868b73b for issue https://github.com/G-Ivan-A/open-ai.ru/issues/34
-# Updated: 2026-05-24T11:31:02.058Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-05-24T11:12:35.088Z for PR creation at branch issue-34-d8afe868b73b for issue https://github.com/G-Ivan-A/open-ai.ru/issues/34
+# Updated: 2026-05-24T11:31:02.058Z

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 This repository is in governance foundation mode. Contributions should preserve traceability and avoid introducing product code before the related structure, contracts, and decisions are documented.
 
+## 🌐 External Teams & Onboarding
+
+New to this project or joining as an external team?<br>
+→ Read [PORTAL_BUILDING_METHODOLOGY.md](docs/architecture/PORTAL_BUILDING_METHODOLOGY.md) to understand HOW we build this portal (process, principles, AI interaction).<br>
+→ Then follow the technical contribution guidelines below.
+
 ## Workflow
 
 1. Start from a GitHub issue with clear acceptance criteria.


### PR DESCRIPTION
## Summary

Fixes G-Ivan-A/open-ai.ru#37.

Adds a concise `External Teams & Onboarding` section to `CONTRIBUTING.md` with a relative link to `docs/architecture/PORTAL_BUILDING_METHODOLOGY.md` and brief onboarding context.

## Validation

- `./tests/validate-repository-structure.sh`
- `git diff --check`
- Reviewed `git diff -- CONTRIBUTING.md` to confirm the change is limited to the requested block.

## Notes

The relative link uses the required path, but `docs/architecture/PORTAL_BUILDING_METHODOLOGY.md` is not present in the current `main`/issue branch checkout. I did not add that file because issue 37 explicitly limits this change to updating `CONTRIBUTING.md`.
